### PR TITLE
DISCO-14: Change to node require/export syntax to fix discovery unit …

### DIFF
--- a/lib/sessionaccount.js
+++ b/lib/sessionaccount.js
@@ -1,10 +1,8 @@
-import request from 'superagent';
-import * as URL from 'url-parse';
-import * as UserInfoStash from 'properly-util-js/lib/user-info-stash';
-import * as Sprintf from 'sprintf-js';
-
-import Cookie from 'js-cookie'
-import Cookies from 'js-cookie'
+const request = require('superagent')
+const URL = require('url-parse')
+const UserInfoStash = require('properly-util-js/lib/user-info-stash')
+const Sprintf = require('sprintf-js')
+const Cookies = require('js-cookie')
 
 
 const STAGING_GRANT_CONFIG = {
@@ -45,7 +43,7 @@ configMap['dev.properlyhomes.ca'] = STAGING_GRANT_DISCO_CONFIG;
 configMap['staging.properlyhomes.ca'] = STAGING_GRANT_DISCO_CONFIG;
 
 
-export class SessionAccount {
+class SessionAccount {
   constructor() {
     this.currentConfig = null;
     this.domainName = "";
@@ -101,7 +99,7 @@ export class SessionAccount {
 
   isLoggedIn() {
     // cast to a native boolean with !!
-    const isLoggedIn = !!(Cookie.get('session.isLoggedIn'));
+    const isLoggedIn = !!(Cookies.get('session.isLoggedIn'));
     return isLoggedIn
   }
 
@@ -134,17 +132,17 @@ export class SessionAccount {
       return Promise.reject(new Error('Not Logged In'));
     }
 
-    const idToken = Cookie.get('session.idToken');
+    const idToken = Cookies.get('session.idToken');
 
     if (idToken) {
       //We have the idToken in a cookie, check if we have performed a check login yet, indicator stored in cookie hasCheckedLoginUserId
-      const userId = Cookie.get("sesssion.hasCheckedLoginUserId");
+      const userId = Cookies.get("sesssion.hasCheckedLoginUserId");
       if (!userId) {
         const completeCheckUserIDPromise = this.performCheckLoginToServer(idToken);
 
         completeCheckUserIDPromise.then(() => {
           const validatedUserId = UserInfoStash.getUserId();
-          Cookie.set("sesssion.hasCheckedLoginUserId", validatedUserId,  { domain: this.domainName, secure: true  });
+          Cookies.set("sesssion.hasCheckedLoginUserId", validatedUserId,  { domain: this.domainName, secure: true  });
         }).then( () => {
           return Promise.resolve(idToken);
         });
@@ -184,7 +182,7 @@ export class SessionAccount {
 
 let gSingletonSession = null;
 
-export const SessionAccountFactory = {
+const SessionAccountFactory = {
   sessionAccountInit: (currentURL) => {
     if (gSingletonSession != null) {
       return gSingletonSession;
@@ -198,3 +196,8 @@ export const SessionAccountFactory = {
 
   getSingleton: () => gSingletonSession,
 };
+
+module.exports = {
+  SessionAccount,
+  SessionAccountFactory,
+}


### PR DESCRIPTION
ES6 import/export statements cause unit tests to fail in the discovery site when these libraries are pulled in as external library dependencies (due to code not being run through babel).  We had to convert to Node require/export syntax as a workaround.