### PR TITLE
disable console.log of cookies

### DIFF
--- a/lib/sessionaccount.js
+++ b/lib/sessionaccount.js
@@ -49,7 +49,7 @@ class SessionAccount {
   }
 
   initAWSOnce(currentURL) {
-    console.dir(Cookies.get())
+    // console.dir(Cookies.get())
 
     const url = new URL(currentURL);
     const hostname = url.hostname;


### PR DESCRIPTION
Noticed this while running the admin site in dev, it clutters up the console quite a bit. I think something like this is best left disabled in master (to be enabled manually locally as needed).