### PR TITLE
Update the UserID in the newest UserInfoStash which uses cookies

### DIFF
--- a/lib/sessionaccount.js
+++ b/lib/sessionaccount.js
@@ -1,6 +1,6 @@
 const request = require('superagent')
 const URL = require('url-parse')
-const UserInfoStash = require('properly-util-js/lib/user-info-stash')
+const { UserInfoStash } = require('@goproperly/web-util');
 const Sprintf = require('sprintf-js')
 const Cookies = require('js-cookie')
 
@@ -98,7 +98,7 @@ class SessionAccount {
 
   performCheckLoginToServer(idToken) {
     const checkLoginTemplate = this.currentConfig.checkLoginTemplate;
-    const userId = encodeURIComponent(UserInfoStash.getUserId());
+    const userId = encodeURIComponent(UserInfoStash.userID);
 
     const uriToUse = Sprintf.sprintf(checkLoginTemplate, userId);
 
@@ -120,7 +120,7 @@ class SessionAccount {
         throw new Error('Must have id from the server on checklogin');
       }
 
-      UserInfoStash.updateUserId(checkLoginResult.id);
+      UserInfoStash.userID = checkLoginResult.id;
     });
 
     return promiseToReturn;
@@ -165,7 +165,7 @@ class SessionAccount {
 
       const promiseToReturn = completeCheckUserIDPromise
         .then(() => {
-          const validatedUserId = UserInfoStash.getUserId();
+          const validatedUserId = UserInfoStash.userID;
           Cookies.set("session.hasCheckedLoginUserId", validatedUserId,  { domain: this.domainName, secure: true  });
           return idToken;
         });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/GoProperly/properly-session-account#readme",
   "dependencies": {
     "js-cookie": "^2.2.1",
-    "properly-util-js": "git+https://github.com/GoProperly/properly-util-js.git",
+    "@goproperly/web-util": "^2.1.1",
     "sprintf-js": "^1.1.2",
     "superagent": "^3.8.3",
     "url-parse": "^1.4.4"


### PR DESCRIPTION
The checklogin process was responsible for ensuring UserInfoStash's UserID gets updated upon successful login.  However, we had 2 (technically 3) versions of UserInfoStash and they were using different methods of storage.  This moves away from the UserInfoStash from properly-util-us, which used window.localStorage.  (Follow up: kill properly-util-js)