### PR TITLE
add support for admin-old domains

### DIFF
--- a/lib/sessionaccount.js
+++ b/lib/sessionaccount.js
@@ -58,8 +58,10 @@ const configMap = {};
 
 configMap['staging.admin.goproperly.com'] = STAGING_GRANT_CONFIG;
 configMap['admin-staging.goproperly.com'] = STAGING_GRANT_CONFIG;
+configMap['admin-staging-old.goproperly.com'] = STAGING_GRANT_CONFIG;
 configMap['dev.admin.goproperly.com'] = STAGING_GRANT_CONFIG;
 configMap['admin.goproperly.com'] = PROD_GRANT_CONFIG;
+configMap['admin-old.goproperly.com'] = PROD_GRANT_CONFIG;
 configMap['www.admin.goproperly.com'] = PROD_GRANT_CONFIG;
 
 configMap['www.properlyhomes.ca'] = PROD_GRANT_DISCO_CONFIG;


### PR DESCRIPTION
This updates the authhandler config used for the old admin app to expect it to be deployed to admin-old.goproperly.com.