### PR TITLE
add support for admin-old domains

### DIFF
--- a/lib/sessionaccount.js
+++ b/lib/sessionaccount.js
@@ -33,8 +33,10 @@ const configMap = {};
 
 configMap['staging.admin.goproperly.com'] = STAGING_GRANT_CONFIG;
 configMap['admin-staging.goproperly.com'] = STAGING_GRANT_CONFIG;
+configMap['admin-staging-old.goproperly.com'] = STAGING_GRANT_CONFIG;
 configMap['dev.admin.goproperly.com'] = STAGING_GRANT_CONFIG;
 configMap['admin.goproperly.com'] = PROD_GRANT_CONFIG;
+configMap['admin-old.goproperly.com'] = PROD_GRANT_CONFIG;
 configMap['www.admin.goproperly.com'] = PROD_GRANT_CONFIG;
 
 configMap['www.properlyhomes.ca'] = STAGING_GRANT_DISCO_CONFIG; //FIXME


### PR DESCRIPTION
This updates the authhandler config used for the old admin app to expect it to be deployed to admin-old.goproperly.com.

This is equivalent to #34, but based on the old commit being used by admin-web-app, essentially excluding the changes from #32 which is causing issues in `admin-web-app` (because the dependency on `web-util` In turn drags in `linoleum` which causes issues in tests).

My intent is to switch `admin-web-app` to using this specific branch, rather than latest `master`.

Hopefully this can all be deleted soon 😄 